### PR TITLE
Disable SSL verification

### DIFF
--- a/lib/jscrambler/client.rb
+++ b/lib/jscrambler/client.rb
@@ -46,7 +46,7 @@ module JScrambler
     end
 
     def api
-      @api ||= Faraday.new(:url => url) do |builder|
+      @api ||= Faraday.new(url: url, ssl: {verify: false}) do |builder|
         builder.use       JScrambler::Middleware::DefaultParams
         builder.use       JScrambler::Middleware::Authentication
         builder.request   :multipart


### PR DESCRIPTION
It’s not the best solution, but works for now. This is to avoid getting
the `Faraday::SSLError: SSL_connect returned=1 errno=0 state=SSLv3 read
server certificate B: certificate verify failed`
